### PR TITLE
Delete account

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - feature/profile-picture-upload
+      - delete-account
 
 jobs:
   QuickChat-backend:

--- a/src/user/user.controller.test.ts
+++ b/src/user/user.controller.test.ts
@@ -283,6 +283,7 @@ describe("User Account Deletion", () => {
   test("should return 404 when user does not exist", async () => {
     const response = await request(app)
       .post("/api/deleteAccount")
+       .set("authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwaG9uZU51bWJlciI6Ijg1MjIwNDE2OTkiLCJpYXQiOjE3NDcwNDI1MzMsImV4cCI6MTc0NzY0NzMzM30.zfGO0o56jDmcPTEulBNiI_aPK15rWG-oKKXvL_64X3w")
       .send({ phoneNumber: "0000000000" })
       .expect(404);
 
@@ -300,19 +301,22 @@ describe("User Account Deletion", () => {
     await request(app).post("/api/users").send(newUser).expect(200);
     const deleteResponse = await request(app)
       .post("/api/deleteAccount")
+      .set("authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwaG9uZU51bWJlciI6Ijg1MjIwNDE2OTkiLCJpYXQiOjE3NDcwNDI1MzMsImV4cCI6MTc0NzY0NzMzM30.zfGO0o56jDmcPTEulBNiI_aPK15rWG-oKKXvL_64X3w")
       .send({ phoneNumber: newUser.phoneNumber })
       .expect(200);
 
     expect(deleteResponse.body.message).toBe("Account deleted succesfully");
 
     const userInDb = await User.findOne({
-      where: { phoneNumber: "" },
+      where: { firstName:'deleteFirstName' },
     });
     expect(userInDb?.isDeleted).toBe(true);
+    expect(userInDb?.phoneNumber).toBe(`deletedPhoneNumber_${userInDb?.id}`);
   });
   test('should test the catch error',async ()=>{
     const response = await request(app)
       .post("/api/deleteAccount")
+       .set("authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwaG9uZU51bWJlciI6Ijg1MjIwNDE2OTkiLCJpYXQiOjE3NDcwNDI1MzMsImV4cCI6MTc0NzY0NzMzM30.zfGO0o56jDmcPTEulBNiI_aPK15rWG-oKKXvL_64X3w")
       .send({ phoneNumber: {invalid:"Invalid password"} })
       .expect(500);
   })

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -150,12 +150,12 @@ export async function deleteAccount(
     } else {
       await User.update(
         {
-          firstName: "",
-          lastName: "",
+          firstName: "deleteFirstName",
+          lastName: "deleteLasttName",
           profilePicture: "",
-          phoneNumber: "",
-          email: "",
-          password: "",
+          phoneNumber: `deletedPhoneNumber_${existingUser.id}`,
+          email:`deletedEmail_${existingUser.id}`,
+          password: "deletePhoneNumber",
           isDeleted: true,
         },
         { where: { phoneNumber } }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -81,8 +81,8 @@ export async function register(
           .json({ accessToken: token, refreshToken: refreshToken, user: user });
       }
     }
-  } catch (e: any) {
-    response.status(500).send(e.message);
+  } catch (error: any) {
+    response.status(500).send(error.message);
   }
 }
 
@@ -131,7 +131,38 @@ export async function login(
       refreshToken,
       user,
     });
-  } catch (e: any) {
-    response.status(500).send(e.message);
+  } catch (error: any) {
+    response.status(500).send(error.message);
+  }
+}
+
+export async function deleteAccount(
+  request: Request,
+  response: Response
+): Promise<void> {
+  try {
+    const { phoneNumber } = request.body;
+    const existingUser = await User.findOne({
+      where: { phoneNumber: request.body.phoneNumber, isDeleted: false },
+    });
+    if (!existingUser) {
+      response.status(404).json({ message: "Invalid phone number" });
+    } else {
+      await User.update(
+        {
+          firstName: "",
+          lastName: "",
+          profilePicture: "",
+          phoneNumber: "",
+          email: "",
+          password: "",
+          isDeleted: true,
+        },
+        { where: { phoneNumber } }
+      );
+      response.status(200).json({ message: "Account deleted succesfully" });
+    }
+  } catch (error: any) {
+    response.status(500).send(error.message);
   }
 }

--- a/src/user/user.route.ts
+++ b/src/user/user.route.ts
@@ -1,8 +1,9 @@
 import express from "express";
-import { login, register } from "./user.controller";
+import { login, register,deleteAccount } from "./user.controller";
 import { validateInputFields, validateLoginInputFields } from "./user.middleware";
 
 export const userRouter = express.Router();
 
 userRouter.post("/api/users", validateInputFields, register);
 userRouter.post("/api/user", validateLoginInputFields, login);
+userRouter.post("/api/deleteAccount", deleteAccount);


### PR DESCRIPTION
# Delete Account API
## This PR adds the following features:

### New POST /api/accountDelete endpoint:
- Allows users to soft-delete their account using their phone number.
### The deletion process:
- Clears out personal fields (firstName, lastName, email, phoneNumber, etc.)
- Sets isDeleted = true

### Unit tests for account deletion:
- Validates response when phone number is not associated with any active account.
- Covers successful account deletion scenario.
- Includes error-handling test to ensure 500 is returned when an internal server error occurs.

### Test Coverage Added:
[x] Invalid phone number (404)
[x] Successful deletion (200)
[x] Internal server error (500)
