### PR TITLE
Implement user blocking functionality route with validations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - post-message
+      - block-user-route
 
 jobs:
   QuickChat-backend:

--- a/server.ts
+++ b/server.ts
@@ -5,6 +5,7 @@ import { syncAssociations } from "./src/associations/associations";
 import { sequelizeInstance } from "./src/connection/dbconnection";
 import { messageRouter } from "./src/message/message.router";
 import { userRouter } from "./src/user/user.route";
+import { blockedUsersRouter } from "./src/blockedusers/blocked-users.router";
 
 dotenv.config({ path: `.env.${process.env.NODE_ENV || "development"}` });
 export const app = express();
@@ -14,6 +15,7 @@ app.use(express.json());
 app.use(cors());
 app.use(userRouter);
 app.use(messageRouter);
+app.use(blockedUsersRouter);
 
 const startServer = async () => {
   try {

--- a/src/blockedusers/blocked-users.controller.test.ts
+++ b/src/blockedusers/blocked-users.controller.test.ts
@@ -1,0 +1,127 @@
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { Sequelize } from "sequelize";
+import { app } from "../../server";
+import { SequelizeConnection } from "../connection/dbconnection";
+import { User } from "../user/user.model";
+import { BlockedUsers } from "./blocked-users.model";
+import { createUser } from "../user/user.controller";
+import { addBlockedUserEntry } from "./blocked-users.service";
+
+describe("Blocked Users Controller", () => {
+  let testInstance: Sequelize;
+  let accessToken: string;
+
+  const blockerPhoneNumber = "+911111111111";
+  const blockedPhoneNumber = "+922222222222";
+
+  beforeAll(async () => {
+    testInstance = SequelizeConnection()!;
+    const blocker = await createUser({
+      phoneNumber: blockerPhoneNumber,
+      firstName: "Blocker",
+      lastName: "User",
+      email: "blocker@example.com",
+      password: "Blocker@1234",
+      isDeleted: false,
+      publicKey: "",
+      privateKey: "",
+      socketId: "",
+    });
+
+    await createUser({
+      phoneNumber: blockedPhoneNumber,
+      firstName: "Blocked",
+      lastName: "User",
+      email: "blocked@example.com",
+      password: "Blocked@1234",
+      isDeleted: false,
+      publicKey: "",
+      privateKey: "",
+      socketId: "",
+    });
+
+    const secret_key = process.env.JSON_WEB_SECRET || "quick_chat_secret";
+    accessToken = jwt.sign({ phoneNumber: blocker.phoneNumber }, secret_key, {
+      expiresIn: "7d",
+    });
+  });
+
+  afterAll(async () => {
+    await BlockedUsers.truncate({ cascade: true });
+    await User.truncate({ cascade: true });
+    await testInstance.close();
+  });
+
+  test("Should return 400 if required fields are missing", async () => {
+    const res = await request(app)
+      .post("/api/block/users")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({ blockerPhoneNumber });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe("Please provide all the necessary fields.");
+  });
+
+  test("Should not allow user to block themselves", async () => {
+    const res = await request(app)
+      .post("/api/block/users")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({
+        blockerPhoneNumber: blockerPhoneNumber,
+        blockedPhoneNumber: blockerPhoneNumber,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe("You cannot block yourself.");
+  });
+
+  test("Should return 500 if any user is not found", async () => {
+    const res = await request(app)
+      .post("/api/block/users")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({
+        blockerPhoneNumber: blockerPhoneNumber,
+        blockedPhoneNumber: "+999999999999",
+      });
+
+    expect(res.status).toBe(500);
+    expect(res.body.message).toBe(
+      "Error while fetching the user User not found with the phone number"
+    );
+  });
+
+  test("Should successfully block the user", async () => {
+    const res = await request(app)
+      .post("/api/block/users")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({
+        blockerPhoneNumber: blockerPhoneNumber,
+        blockedPhoneNumber: blockedPhoneNumber,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("User blocked successfully.");
+    expect(res.body.blockedUsersDetails.blocker).toBeDefined();
+    expect(res.body.blockedUsersDetails.blocked).toBeDefined();
+  });
+
+  test("Should return 409 if already blocked", async () => {
+    const res = await request(app)
+      .post("/api/block/users")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({
+        blockerPhoneNumber: blockerPhoneNumber,
+        blockedPhoneNumber: blockedPhoneNumber,
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.message).toBe("You have already blocked this user.");
+  });
+
+  test("should throw error if invalid blockerId and blockedId are sent ", async () => {
+    await expect(addBlockedUserEntry("blockerId", "blockedId")).rejects.toThrow(
+      `Error occured while blocking user : invalid input syntax for type uuid: \"blockerId\"`
+    );
+  });
+});

--- a/src/blockedusers/blocked-users.controller.test.ts
+++ b/src/blockedusers/blocked-users.controller.test.ts
@@ -16,7 +16,7 @@ describe("Blocked Users Controller", () => {
   const blockedPhoneNumber = "+922222222222";
 
   beforeAll(async () => {
-    testInstance = SequelizeConnection()!;
+    testInstance = SequelizeConnection();
     const blocker = await createUser({
       phoneNumber: blockerPhoneNumber,
       firstName: "Blocker",
@@ -121,7 +121,7 @@ describe("Blocked Users Controller", () => {
 
   test("should throw error if invalid blockerId and blockedId are sent ", async () => {
     await expect(addBlockedUserEntry("blockerId", "blockedId")).rejects.toThrow(
-      `Error occured while blocking user : invalid input syntax for type uuid: \"blockerId\"`
+      `Error occurred while blocking user : invalid input syntax for type uuid: \"blockerId\"`
     );
   });
 });

--- a/src/blockedusers/blocked-users.controller.ts
+++ b/src/blockedusers/blocked-users.controller.ts
@@ -1,0 +1,50 @@
+import { Request, Response } from "express";
+import { findByPhoneNumber } from "../utils/findByPhoneNumber";
+import { BlockedUsers } from "./blocked-users.model";
+import { addBlockedUserEntry } from "./blocked-users.service";
+
+export const executeUserBlock = async (req: Request, res: Response) => {
+  try {
+    const blockerPhoneNumber = req.body.blockerPhoneNumber;
+    const blockedPhoneNumber = req.body.blockedPhoneNumber;
+
+    if (!blockerPhoneNumber || !blockedPhoneNumber) {
+      res
+        .status(400)
+        .json({ message: "Please provide all the necessary fields." });
+      return;
+    }
+
+    const blockerId = await findByPhoneNumber(blockerPhoneNumber);
+    const blockedId = await findByPhoneNumber(blockedPhoneNumber);
+
+    if (blockerId === blockedId) {
+      res.status(400).json({ message: "You cannot block yourself." });
+      return;
+    }
+
+    const existingBlockedUser = await BlockedUsers.findOne({
+      where: {
+        blocker: blockerId,
+        blocked: blockedId,
+      },
+    });
+
+    if (existingBlockedUser) {
+      res.status(409).json({ message: "You have already blocked this user." });
+      return;
+    }
+
+    const blockedUsers: BlockedUsers = await addBlockedUserEntry(
+      blockerId,
+      blockedId
+    );
+
+    res.status(200).json({
+      message: "User blocked successfully.",
+      blockedUsersDetails: blockedUsers,
+    });
+  } catch (error) {
+    res.status(500).json({ message: `${(error as Error).message}` });
+  }
+};

--- a/src/blockedusers/blocked-users.model.ts
+++ b/src/blockedusers/blocked-users.model.ts
@@ -27,7 +27,7 @@ BlockedUsers.init(
       allowNull: false,
     },
     blocker: {
-      type: DataTypes.STRING,
+      type: DataTypes.UUID,
       unique: true,
       allowNull: false,
       references: {
@@ -37,7 +37,7 @@ BlockedUsers.init(
       field: "blocker_id",
     },
     blocked: {
-      type: DataTypes.STRING,
+      type: DataTypes.UUID,
       allowNull: false,
       references: {
         model: User,

--- a/src/blockedusers/blocked-users.router.ts
+++ b/src/blockedusers/blocked-users.router.ts
@@ -1,0 +1,8 @@
+import express from 'express'
+import { authenticateToken } from '../user/user.middleware'
+import { executeUserBlock } from './blocked-users.controller';
+
+
+export const blockedUsersRouter = express.Router();
+
+blockedUsersRouter.post('/api/block/users',authenticateToken, executeUserBlock);

--- a/src/blockedusers/blocked-users.service.ts
+++ b/src/blockedusers/blocked-users.service.ts
@@ -11,6 +11,7 @@ export const addBlockedUserEntry = async (
     });
     return blockUserDetails;
   } catch (error) {
-    throw new Error(`Error occured while blocking user : ${(error as Error).message}`);
+    throw new Error(`Error occurred while blocking user : ${(error as Error).message}`);
   }
 };
+

--- a/src/blockedusers/blocked-users.service.ts
+++ b/src/blockedusers/blocked-users.service.ts
@@ -1,0 +1,16 @@
+import { BlockedUsers } from "./blocked-users.model";
+
+export const addBlockedUserEntry = async (
+  blockerId: string,
+  blockedId: string
+): Promise<BlockedUsers> => {
+  try {
+    const blockUserDetails = await BlockedUsers.create({
+      blocker: blockerId,
+      blocked: blockedId,
+    });
+    return blockUserDetails;
+  } catch (error) {
+    throw new Error(`Error occured while blocking user : ${(error as Error).message}`);
+  }
+};


### PR DESCRIPTION
This PR introduces the **user blocking feature** route, enabling one user to block another with proper validations and database persistence.

---

## 🚀 Features Added

- `POST /api/block/users`: API endpoint to allow a user to block another user.
- Sequelize model `BlockedUsers` with fields:
  - `blocker`
  - `blocked`
- Service method `addBlockedUserEntry` to handle DB operations.

---

## ✅ Validations

- Prevent blocking without providing all required fields.
- Prevent a user from blocking themselves.
- Return appropriate error if either user is not found.
- Prevent duplicate blocking (returns a `409 Conflict` if already blocked).

---


## 🧼 Setup

- Integrated `blockedUsersRouter` into the main Express app using `app.use()`.
- Added token-based authentication middleware for secure route access.

