### PR TITLE
Add API to Check Block Status Between Two Users

### DIFF
--- a/src/userRestriction/userRestriction.controller.test.ts
+++ b/src/userRestriction/userRestriction.controller.test.ts
@@ -359,7 +359,7 @@ describe("Tests for checking blocked status functionality", () => {
     expect(response.body.unblockedUsersDetails.blocked).toBeDefined();
   });
 
-  test("Should return false, if user is blocked", async () => {
+  test("Should return false, if user is not blocked", async () => {
     const response = await request(app)
       .post("/api/users/block-status")
       .set({ Authorization: `Bearer ${accessToken}` })

--- a/src/userRestriction/userRestriction.controller.test.ts
+++ b/src/userRestriction/userRestriction.controller.test.ts
@@ -5,7 +5,7 @@ import { app } from "../../server";
 import { SequelizeConnection } from "../connection/dbconnection";
 import { createUser } from "../user/user.controller";
 import { User } from "../user/user.model";
-import { UserRestriction } from "./userRestriction.model"; 
+import { UserRestriction } from "./userRestriction.model";
 import {
   addBlockedUserEntry,
   removeBlockedUserEntry,
@@ -259,5 +259,130 @@ describe("Blocked Users Controller", () => {
         "Blocked entry not found."
       );
     });
+  });
+});
+
+describe("Tests for checking blocked status functionality", () => {
+  let testInstance: Sequelize;
+  let accessToken: string;
+
+  const blockerPhoneNumber = "+916303961097";
+  const blockedPhoneNumber = "+916303974914";
+
+  beforeAll(async () => {
+    testInstance = SequelizeConnection();
+    const blocker = await createUser({
+      phoneNumber: blockerPhoneNumber,
+      firstName: "Usha",
+      lastName: "Sri",
+      email: "uski@gmail.com",
+      password: "blockeR@1234",
+      isDeleted: false,
+      publicKey: "",
+      privateKey: "",
+      socketId: "",
+    });
+
+    await createUser({
+      phoneNumber: blockedPhoneNumber,
+      firstName: "Mamatha",
+      lastName: "Niyal",
+      email: "mammu@gmail.com",
+      password: "blockeD@1234",
+      isDeleted: false,
+      publicKey: "",
+      privateKey: "",
+      socketId: "",
+    });
+
+    const secret_key = process.env.JSON_WEB_SECRET || "quick_chat_secret";
+    accessToken = jwt.sign({ phoneNumber: blocker.phoneNumber }, secret_key, {
+      expiresIn: "7d",
+    });
+  });
+
+  afterAll(async () => {
+    await UserRestriction.truncate({ cascade: true });
+    await User.truncate({ cascade: true });
+    await testInstance.close();
+  });
+
+  test("Should return 400 if required fields are missing", async () => {
+    const res = await request(app)
+      .post("/api/users/block-status")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({ blockerPhoneNumber });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe("Please provide the necessary details.");
+  });
+
+  test("Should block a user i.e., create an entry in userRestriction table", async () => {
+    const res = await request(app)
+      .post("/api/block/users")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({
+        blockerPhoneNumber: blockerPhoneNumber,
+        blockedPhoneNumber: blockedPhoneNumber,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("User blocked successfully.");
+    expect(res.body.blockedUsersDetails.blocker).toBeDefined();
+    expect(res.body.blockedUsersDetails.blocked).toBeDefined();
+  });
+
+  test("Should return true, if user is blocked", async () => {
+    const response = await request(app)
+      .post("/api/users/block-status")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({
+        blockerPhoneNumber: blockerPhoneNumber,
+        blockedPhoneNumber: blockedPhoneNumber,
+      })
+      .expect(200);
+    expect(response.body.isBlocked).toBe(true);
+  });
+
+  test("Should successfully unblock the user", async () => {
+    const response = await request(app)
+      .post("/api/unblock/users")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({
+        blockerPhoneNumber: blockerPhoneNumber,
+        blockedPhoneNumber: blockedPhoneNumber,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("User unblocked successfully.");
+    expect(response.body.unblockedUsersDetails.blocker).toBeDefined();
+    expect(response.body.unblockedUsersDetails.blocked).toBeDefined();
+  });
+
+  test("Should return false, if user is blocked", async () => {
+    const response = await request(app)
+      .post("/api/users/block-status")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({
+        blockerPhoneNumber: blockerPhoneNumber,
+        blockedPhoneNumber: blockedPhoneNumber,
+      })
+      .expect(200);
+    expect(response.body.isBlocked).toBe(false);
+  });
+
+  test("Should return 500 if any user is not found", async () => {
+    const response = await request(app)
+      .post("/api/users/block-status")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({
+        blockerPhoneNumber: blockerPhoneNumber,
+        blockedPhoneNumber: "+999999999999",
+      });
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toContain(
+      "User not found with the phone number"
+    );
   });
 });

--- a/src/userRestriction/userRestriction.controller.ts
+++ b/src/userRestriction/userRestriction.controller.ts
@@ -103,10 +103,10 @@ export const checkBlockStatus = async (req: Request, res: Response) => {
         .json({ message: "Please provide the necessary details." });
       return;
     }
-    const senderId = await findByPhoneNumber(blockerPhoneNumber);
-    const receiverId = await findByPhoneNumber(blockedPhoneNumber);
+    const blocker = await findByPhoneNumber(blockerPhoneNumber);
+    const blocked = await findByPhoneNumber(blockedPhoneNumber);
     const blockRecord = await UserRestriction.findOne({
-      where: { blocker: senderId, blocked: receiverId },
+      where: { blocker: blocker, blocked: blocked },
     });
     res.status(200).json({ isBlocked: !!blockRecord });
     return;

--- a/src/userRestriction/userRestriction.controller.ts
+++ b/src/userRestriction/userRestriction.controller.ts
@@ -93,3 +93,28 @@ export const unblockUserAccount = async (req: Request, res: Response) => {
     res.status(500).json({ message: `${(error as Error).message}` });
   }
 };
+
+export const checkBlockStatus = async (req: Request, res: Response) => {
+  try {
+    const { blockerPhoneNumber, blockedPhoneNumber } = req.body;
+    if (!blockerPhoneNumber || !blockedPhoneNumber) {
+      res
+        .status(400)
+        .json({ message: "Please provide the necessary details." });
+      return;
+    }
+    const senderId = await findByPhoneNumber(blockerPhoneNumber);
+    const receiverId = await findByPhoneNumber(blockedPhoneNumber);
+    const blockRecord = await UserRestriction.findOne({
+      where: { blocker: senderId, blocked: receiverId },
+    });
+    res.status(200).json({ isBlocked: !!blockRecord });
+    return;
+  } catch (error) {
+    res.status(500).json({
+      error: `Error while fetching user block status: ${
+        (error as Error).message
+      }`,
+    });
+  }
+};

--- a/src/userRestriction/userRestriction.router.ts
+++ b/src/userRestriction/userRestriction.router.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { authenticateToken } from "../user/user.middleware";
 import {
   blockUserAccount,
+  checkBlockStatus,
   unblockUserAccount,
 } from "./userRestriction.controller";
 
@@ -17,3 +18,8 @@ userRestrictionRouter.post(
   authenticateToken,
   unblockUserAccount
 );
+userRestrictionRouter.post(
+  "/api/users/block-status",
+  authenticateToken,
+  checkBlockStatus
+)


### PR DESCRIPTION
This PR introduces a new POST endpoint `/api/users/block-status` to determine if one user has blocked another based on their phone numbers. 

### Implementation
- Extracts `blockerPhoneNumber` and `blockedPhoneNumber` from the request body.
- Validates input and retrieves corresponding user IDs using `findByPhoneNumber`.
- Checks the UserRestriction table for an existing block record.
- Returns a JSON response with `isBlocked`: true/false based on the query result.
### Test
- All Test cases are passed with 100% coverage.