### PR TITLE
Implement API to fetch user's chat list with latest message and unread count

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: QuickChat-backend
 on:
   push:
     branches:
-      - main
+      - get-user-chats
 
 jobs:
   QuickChat-backend:

--- a/src/chat/chat.controller.test.ts
+++ b/src/chat/chat.controller.test.ts
@@ -262,6 +262,8 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       isDeleted: false,
       publicKey: "publicKey",
       privateKey: "privateKey",
+      isLogin: false,
+      deviceId: "abcd"
     });
     const receiverA = await createUser({
       firstName: "receiver",
@@ -271,6 +273,8 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       isDeleted: false,
       publicKey: "publicKey",
       privateKey: "privateKey",
+      isLogin: false,
+      deviceId: "efgh"
     });
     const receiverB = await createUser({
       firstName: "receiver",
@@ -280,6 +284,8 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       isDeleted: false,
       publicKey: "publicKey",
       privateKey: "privateKey",
+      isLogin: false,
+      deviceId: "ijkl"
     });
     const receiverC = await createUser({
       firstName: "receiver",
@@ -289,6 +295,8 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       isDeleted: false,
       publicKey: "publicKey",
       privateKey: "privateKey",
+      isLogin: false,
+      deviceId: "mnop"
     });
     accessToken = jwt.sign(
       { phoneNumber: senderPhoneNumber },
@@ -325,6 +333,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: receiverAPhoneNumber,
       content: "Hello, I am sending you a message!",
       timeStamp: "2025-05-25T14:35:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -338,6 +347,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: senderPhoneNumber,
       content: "Hello, I am giving reply to you!",
       timeStamp: "2025-05-25T14:38:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -351,6 +361,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: receiverAPhoneNumber,
       content: "Thanks for giving reply!",
       timeStamp: "2025-05-25T14:45:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -366,6 +377,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: receiverBPhoneNumber,
       content: "Hello, I am sending you a message!",
       timeStamp: "2025-05-25T14:50:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -379,6 +391,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: senderPhoneNumber,
       content: "Hello, I am giving reply to you!",
       timeStamp: "2025-05-25T14:55:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -392,6 +405,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: receiverBPhoneNumber,
       content: "Thanks for giving reply!",
       timeStamp: "2025-05-25T15:00:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -405,6 +419,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: senderPhoneNumber,
       content: "Your welcome.",
       timeStamp: "2025-05-25T15:05:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -420,6 +435,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: receiverCPhoneNumber,
       content: "Hello, I am sending you a message!",
       timeStamp: "2025-05-25T14:50:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -433,6 +449,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: senderPhoneNumber,
       content: "Hello, I am giving reply to you!",
       timeStamp: "2025-05-25T14:55:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -446,6 +463,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: receiverCPhoneNumber,
       content: "Thanks for giving reply!",
       timeStamp: "2025-05-25T15:00:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -459,6 +477,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: senderPhoneNumber,
       content: "Your welcome.",
       timeStamp: "2025-05-25T15:05:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -472,6 +491,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: receiverCPhoneNumber,
       content: "Hello Again! Sorry for Deleting Chat with you.",
       timeStamp: "2025-05-25T15:10:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -519,6 +539,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: senderPhoneNumber,
       content: "Hello, I am sending you a message!",
       timeStamp: "2025-05-25T14:50:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -532,6 +553,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: senderPhoneNumber,
       content: "Hello, I am giving reply to you!",
       timeStamp: "2025-05-25T14:55:00Z",
+      status:'sent'
     };
 
     await request(app)
@@ -619,6 +641,7 @@ describe("Testing the functionality of retrieving all the messages of a user", (
       receiverPhoneNumber: receiverCPhoneNumber,
       content: "Message after clearing",
       timeStamp: "2025-05-25T18:10:00Z",
+      status:'sent'
     };
 
     await request(app)

--- a/src/chat/chat.controller.test.ts
+++ b/src/chat/chat.controller.test.ts
@@ -217,3 +217,421 @@ describe("Testing the functionality of retrieving the messages of two users", ()
     expect(response.body.error).toMatch(/User not found/i);
   }, 10000);
 });
+
+describe("Testing the functionality of retrieving all the messages of a user", () => {
+  let testInstance: Sequelize;
+
+  beforeAll(() => {
+    testInstance = SequelizeConnection();
+  });
+
+  afterAll(async () => {
+    await Message.truncate({ cascade: true });
+    await Conversation.truncate({ cascade: true });
+    await Chat.truncate({ cascade: true });
+    await User.truncate({ cascade: true });
+    testInstance.close();
+  });
+
+  let accessToken: string = "";
+  const secret_key = process.env.JSON_WEB_SECRET || "quick_chat_secret";
+  const senderPhoneNumber = "+916303974914";
+  const receiverAPhoneNumber = "+916303552761";
+  const receiverBPhoneNumber = "+916303552762";
+  const receiverCPhoneNumber = "+916303552763";
+
+  test("should create four users in the database to have chat", async () => {
+    const sender = await createUser({
+      firstName: "sender",
+      lastName: "A",
+      phoneNumber: senderPhoneNumber,
+      password: "Pass@word1",
+      isDeleted: false,
+      publicKey: "publicKey",
+      privateKey: "privateKey",
+    });
+    const receiverA = await createUser({
+      firstName: "receiver",
+      lastName: "A",
+      phoneNumber: receiverAPhoneNumber,
+      password: "Pass@word1",
+      isDeleted: false,
+      publicKey: "publicKey",
+      privateKey: "privateKey",
+    });
+    const receiverB = await createUser({
+      firstName: "receiver",
+      lastName: "B",
+      phoneNumber: receiverBPhoneNumber,
+      password: "Pass@word2",
+      isDeleted: false,
+      publicKey: "publicKey",
+      privateKey: "privateKey",
+    });
+    const receiverC = await createUser({
+      firstName: "receiver",
+      lastName: "C",
+      phoneNumber: receiverCPhoneNumber,
+      password: "Pass@word3",
+      isDeleted: false,
+      publicKey: "publicKey",
+      privateKey: "privateKey",
+    });
+    accessToken = jwt.sign(
+      { phoneNumber: senderPhoneNumber },
+      secret_key.toString(),
+      {
+        expiresIn: "7d",
+      }
+    );
+    expect(sender.id).toBeTruthy();
+    expect(receiverA.id).toBeTruthy();
+    expect(receiverB.id).toBeTruthy();
+    expect(receiverC.id).toBeTruthy();
+  });
+
+  test("Should return 400 if necessary details are not provided", async () => {
+    await request(app)
+      .post("/api/chats/user")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .expect(400);
+  });
+
+  test("Should return empty array if user don't have any chats", async () => {
+    const chatsOfSender = await request(app)
+      .post("/api/chats/user")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({ userPhoneNumber: senderPhoneNumber })
+      .expect(200);
+    expect(chatsOfSender.body.chats.length).toBe(0);
+  });
+
+  test("Should create necessary messages from sender to receiverA successfully", async () => {
+    const messageAPayload = {
+      senderPhoneNumber: senderPhoneNumber,
+      receiverPhoneNumber: receiverAPhoneNumber,
+      content: "Hello, I am sending you a message!",
+      timeStamp: "2025-05-25T14:35:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageAPayload)
+      .expect(200);
+
+    const messageBPayload = {
+      senderPhoneNumber: receiverAPhoneNumber,
+      receiverPhoneNumber: senderPhoneNumber,
+      content: "Hello, I am giving reply to you!",
+      timeStamp: "2025-05-25T14:38:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageBPayload)
+      .expect(200);
+
+    const messageCPayload = {
+      senderPhoneNumber: senderPhoneNumber,
+      receiverPhoneNumber: receiverAPhoneNumber,
+      content: "Thanks for giving reply!",
+      timeStamp: "2025-05-25T14:45:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageCPayload)
+      .expect(200);
+  });
+
+  test("Should create necessary messages from sender to receiverB succesfully", async () => {
+    const messageAPayload = {
+      senderPhoneNumber: senderPhoneNumber,
+      receiverPhoneNumber: receiverBPhoneNumber,
+      content: "Hello, I am sending you a message!",
+      timeStamp: "2025-05-25T14:50:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageAPayload)
+      .expect(200);
+
+    const messageBPayload = {
+      senderPhoneNumber: receiverBPhoneNumber,
+      receiverPhoneNumber: senderPhoneNumber,
+      content: "Hello, I am giving reply to you!",
+      timeStamp: "2025-05-25T14:55:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageBPayload)
+      .expect(200);
+
+    const messageCPayload = {
+      senderPhoneNumber: senderPhoneNumber,
+      receiverPhoneNumber: receiverBPhoneNumber,
+      content: "Thanks for giving reply!",
+      timeStamp: "2025-05-25T15:00:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageCPayload)
+      .expect(200);
+
+    const messageDPayload = {
+      senderPhoneNumber: receiverBPhoneNumber,
+      receiverPhoneNumber: senderPhoneNumber,
+      content: "Your welcome.",
+      timeStamp: "2025-05-25T15:05:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageDPayload)
+      .expect(200);
+  });
+
+  test("Should create necessary messages from sender to receiverC succesfully", async () => {
+    const messageAPayload = {
+      senderPhoneNumber: senderPhoneNumber,
+      receiverPhoneNumber: receiverCPhoneNumber,
+      content: "Hello, I am sending you a message!",
+      timeStamp: "2025-05-25T14:50:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageAPayload)
+      .expect(200);
+
+    const messageBPayload = {
+      senderPhoneNumber: receiverCPhoneNumber,
+      receiverPhoneNumber: senderPhoneNumber,
+      content: "Hello, I am giving reply to you!",
+      timeStamp: "2025-05-25T14:55:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageBPayload)
+      .expect(200);
+
+    const messageCPayload = {
+      senderPhoneNumber: senderPhoneNumber,
+      receiverPhoneNumber: receiverCPhoneNumber,
+      content: "Thanks for giving reply!",
+      timeStamp: "2025-05-25T15:00:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageCPayload)
+      .expect(200);
+
+    const messageDPayload = {
+      senderPhoneNumber: receiverCPhoneNumber,
+      receiverPhoneNumber: senderPhoneNumber,
+      content: "Your welcome.",
+      timeStamp: "2025-05-25T15:05:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageDPayload)
+      .expect(200);
+
+    const messageEPayload = {
+      senderPhoneNumber: senderPhoneNumber,
+      receiverPhoneNumber: receiverCPhoneNumber,
+      content: "Hello Again! Sorry for Deleting Chat with you.",
+      timeStamp: "2025-05-25T15:10:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageEPayload)
+      .expect(200);
+  });
+
+  test("should update the messages status sent by receiverB to sender before the provided timestamp", async () => {
+    const payload = {
+      senderPhoneNumber: receiverBPhoneNumber,
+      receiverPhoneNumber: senderPhoneNumber,
+      timestamp: "2025-05-25T14:59:00Z",
+      previousStatus: "sent",
+      currentStatus: "read",
+    };
+
+    const messageResponse = await request(app)
+      .put("/api/messages/status")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(payload)
+      .expect(200);
+    expect(messageResponse.body.count).toBe(1);
+  });
+
+  test("should delete the chat with receiverC", async () => {
+    const response = await request(app)
+      .post("/api/chat/delete")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({
+        senderPhoneNumber: senderPhoneNumber,
+        receiverPhoneNumber: receiverCPhoneNumber,
+        timestamp: "2025-05-25T15:15:00Z",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Conversation deleted for the user.");
+    expect(response.body.count).toBe(1);
+  });
+
+  test("Should create necessary messages from sender to sender succesfully", async () => {
+    const messageAPayload = {
+      senderPhoneNumber: senderPhoneNumber,
+      receiverPhoneNumber: senderPhoneNumber,
+      content: "Hello, I am sending you a message!",
+      timeStamp: "2025-05-25T14:50:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageAPayload)
+      .expect(200);
+
+    const messageBPayload = {
+      senderPhoneNumber: senderPhoneNumber,
+      receiverPhoneNumber: senderPhoneNumber,
+      content: "Hello, I am giving reply to you!",
+      timeStamp: "2025-05-25T14:55:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageBPayload)
+      .expect(200);
+  });
+
+  test("should fetch the chats of sender with receiverA and receiverBnp successfully", async () => {
+    const chatsOfSender = await request(app)
+      .post("/api/chats/user")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({ userPhoneNumber: senderPhoneNumber })
+      .expect(200);
+
+    expect(Array.isArray(chatsOfSender.body.chats)).toBe(true);
+    expect(chatsOfSender.body.chats).toHaveLength(3);
+
+    const receiverBChat = chatsOfSender.body.chats[0];
+    const selfChat = chatsOfSender.body.chats[1];
+    const receiverAChat = chatsOfSender.body.chats[2];
+
+    expect(selfChat).toBeDefined();
+    expect(selfChat.chatId).toBeTruthy();
+    expect(selfChat.contactName).toBe("sender A");
+    expect(selfChat.contactProfilePic).toBeNull();
+    expect(selfChat.phoneNumber).toBe(senderPhoneNumber);
+    expect(selfChat.lastMessageText).toBe("Hello, I am giving reply to you!");
+    expect(selfChat.lastMessageType).toBe("sentMessage");
+    expect(selfChat.lastMessageStatus).toBe("sent");
+    expect(selfChat.lastMessageTimestamp).toBe("2025-05-25T14:55:00.000Z");
+    expect(selfChat.unreadCount).toBe(2);
+
+    expect(receiverBChat).toBeDefined();
+    expect(receiverBChat.chatId).toBeTruthy();
+    expect(receiverBChat.contactName).toBe("receiver B");
+    expect(receiverBChat.contactProfilePic).toBeNull();
+    expect(receiverBChat.phoneNumber).toBe(receiverBPhoneNumber);
+    expect(receiverBChat.lastMessageText).toBe("Your welcome.");
+    expect(receiverBChat.lastMessageType).toBe("receivedMessage");
+    expect(receiverBChat.lastMessageStatus).toBeNull();
+    expect(receiverBChat.lastMessageTimestamp).toBe("2025-05-25T15:05:00.000Z");
+    expect(receiverBChat.unreadCount).toBe(1);
+
+    expect(receiverAChat).toBeDefined();
+    expect(receiverAChat.chatId).toBeTruthy();
+    expect(receiverAChat.contactName).toBe("receiver A");
+    expect(receiverAChat.contactProfilePic).toBeNull();
+    expect(receiverAChat.phoneNumber).toBe(receiverAPhoneNumber);
+    expect(receiverAChat.lastMessageText).toBe("Thanks for giving reply!");
+    expect(receiverAChat.lastMessageType).toBe("sentMessage");
+    expect(receiverAChat.lastMessageStatus).toBe("sent");
+    expect(receiverAChat.lastMessageTimestamp).toBe("2025-05-25T14:45:00.000Z");
+    expect(receiverAChat.unreadCount).toBe(1);
+  });
+
+  test("should fetch chats of receiverA with sender", async () => {
+    const chatsOfSender = await request(app)
+      .post("/api/chats/user")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({ userPhoneNumber: receiverAPhoneNumber })
+      .expect(200);
+
+    expect(Array.isArray(chatsOfSender.body.chats)).toBe(true);
+    expect(chatsOfSender.body.chats).toHaveLength(1);
+
+    const chat = chatsOfSender.body.chats[0];
+
+    expect(chat).toBeDefined();
+    expect(chat.chatId).toBeTruthy();
+    expect(chat.contactName).toBe("sender A");
+    expect(chat.contactProfilePic).toBeNull();
+    expect(chat.phoneNumber).toBe(senderPhoneNumber);
+    expect(chat.lastMessageText).toBe("Thanks for giving reply!");
+    expect(chat.lastMessageType).toBe("receivedMessage");
+    expect(chat.lastMessageStatus).toBeNull();
+    expect(chat.lastMessageTimestamp).toBe("2025-05-25T14:45:00.000Z");
+    expect(chat.unreadCount).toBe(2);
+  });
+
+  test("should include chat in results when lastClearedAt is before the last message", async () => {
+    const messageAPayload = {
+      senderPhoneNumber: senderPhoneNumber,
+      receiverPhoneNumber: receiverCPhoneNumber,
+      content: "Message after clearing",
+      timeStamp: "2025-05-25T18:10:00Z",
+    };
+
+    await request(app)
+      .post("/api/message")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send(messageAPayload)
+      .expect(200);
+
+    const chatsOfSender = await request(app)
+      .post("/api/chats/user")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({ userPhoneNumber: senderPhoneNumber })
+      .expect(200);
+
+    const receiverCChat = chatsOfSender.body.chats[0];
+
+    expect(receiverCChat).toBeDefined();
+    expect(receiverCChat.lastMessageText).toBe("Message after clearing");
+    expect(receiverCChat.lastMessageTimestamp).toBe("2025-05-25T18:10:00.000Z");
+  });
+
+  test("should throw error if phone number provided is wrong", async () => {
+    await request(app)
+      .post("/api/chats/user")
+      .set({ Authorization: `Bearer ${accessToken}` })
+      .send({ userPhoneNumber: "+919876543210" })
+      .expect(500);
+  });
+});

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -2,7 +2,8 @@ import { Request, Response } from "express";
 import { Op } from "sequelize";
 import { Chat } from "../chat/chat.model";
 import { Conversation } from "../conversation/conversation.model";
-import { Message } from "../message/message.model";
+import { Message, MessageStatus } from "../message/message.model";
+import { ChatsOfUser } from "../types/chats";
 import { User } from "../user/user.model";
 import { findByPhoneNumber } from "../utils/findByPhoneNumber";
 
@@ -66,5 +67,124 @@ export const userChats = async (req: Request, res: Response) => {
     });
   } catch (error) {
     res.status(500).json({ error: "Internal Server Error" + error });
+  }
+};
+
+export const getChatsOfUser = async (req: Request, res: Response) => {
+  try {
+    const userPhoneNumber = req.body.userPhoneNumber;
+    if (!userPhoneNumber) {
+      res.status(400).json({ message: "Please provide phone number." });
+      return;
+    }
+    const userId = await findByPhoneNumber(userPhoneNumber);
+
+    const chats = await Chat.findAll({
+      where: {
+        [Op.or]: [{ userAId: userId }, { userBId: userId }],
+      },
+      include: [
+        {
+          model: Message,
+          limit: 1,
+          order: [["createdAt", "DESC"]],
+          required: true,
+        },
+        {
+          model: User,
+          as: "userA",
+          attributes: [
+            "id",
+            "firstName",
+            "lastName",
+            "profilePicture",
+            "phoneNumber",
+          ],
+        },
+        {
+          model: User,
+          as: "userB",
+          attributes: [
+            "id",
+            "firstName",
+            "lastName",
+            "profilePicture",
+            "phoneNumber",
+          ],
+        },
+      ],
+    });
+
+    const chatsOfUser = [];
+
+    for (const chat of chats) {
+      const chatData: ChatsOfUser = chat.toJSON();
+      let contact;
+      if (chat.userAId === chat.userBId) {
+        contact = chatData.userA;
+      } else {
+        contact = chat.userAId === userId ? chatData.userB : chatData.userA;
+      }
+
+      const unreadCount = await Message.count({
+        where: {
+          chatId: chat.id,
+          senderId: contact.id,
+          receiverId: userId,
+          status: { [Op.ne]: "read" as MessageStatus },
+        },
+      });
+
+      const conversation = await Conversation.findOne({
+        where: {
+          userId: userId,
+          chatId: chatData.id,
+        },
+      });
+
+      let lastMessage;
+      if (
+        conversation &&
+        conversation.isDeleted &&
+        conversation.lastClearedAt
+      ) {
+        lastMessage =
+          conversation.lastClearedAt < chatData.Messages[0].createdAt
+            ? chatData.Messages[0]
+            : null;
+      } else {
+        lastMessage = chatData.Messages[0];
+      }
+
+      if (!lastMessage) {
+        continue;
+      }
+
+      chatsOfUser.push({
+        chatId: chat.id,
+        contactProfilePic: contact.profilePicture || null,
+        contactName: `${contact.firstName} ${contact.lastName}`,
+        phoneNumber: contact.phoneNumber,
+        lastMessageText: lastMessage.content,
+        lastMessageType:
+          lastMessage.senderId === userId ? "sentMessage" : "receivedMessage",
+        lastMessageStatus:
+          lastMessage.senderId === userId ? lastMessage.status : null,
+        lastMessageTimestamp: lastMessage.createdAt,
+        unreadCount: unreadCount,
+      });
+
+      chatsOfUser.sort((chatA, chatB) => {
+        const timeA = new Date(chatA.lastMessageTimestamp).getTime();
+        const timeB = new Date(chatB.lastMessageTimestamp).getTime();
+        return timeB - timeA; 
+      });
+    }
+
+    res.status(200).json({ chats: chatsOfUser });
+  } catch (error) {
+    res.status(500).json({
+      error: `Error getting chats of user ${(error as Error).message}`,
+    });
   }
 };

--- a/src/chat/chat.router.ts
+++ b/src/chat/chat.router.ts
@@ -1,7 +1,8 @@
 import express from "express";
 import { authenticateToken } from "../user/user.middleware";
-import { userChats } from "./chat.controller";
+import { getChatsOfUser, userChats } from "./chat.controller";
 
 export const chatRouter = express.Router();
 
 chatRouter.post("/api/users/messages", authenticateToken, userChats);
+chatRouter.post("/api/chats/user", authenticateToken, getChatsOfUser)

--- a/src/types/chats.ts
+++ b/src/types/chats.ts
@@ -1,0 +1,22 @@
+import { DbUser } from "./user";
+
+export type ChatsOfUser = {
+  id: string;
+  userAId: string;
+  userBId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  userA: Partial<DbUser>;
+  userB: Partial<DbUser>;
+  Messages: Array<{
+    id: string;
+    chatId: string;
+    senderId: string;
+    receiverId: string;
+    content: string;
+    status: string;
+    isEncrypted: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+  }>;
+};


### PR DESCRIPTION
This PR introduces the new API with `getChatsOfUser` controller method which returns all the chats of the user:

### Implementation:
- Accepts a user's phone number and retrieves their associated chats.
- For each chat, determines the chat partner, last message, and unread message count.
- Handles soft-deleted conversations using Conversation.lastClearedAt to filter out older messages.

### Return Objects includes:
- Contact name and profile picture
- Last message type (sentMessage / receivedMessage)
- Last message delivery status (for sent messages)
- Timestamp of the last message
- Unread message count
- Sorts the chats based on the latest message timestamp in descending order.

### Tests
- All test cases have been passed.