### PR TITLE
Emit internet_connection Event via Socket to Notify Frontend network status

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - emit-internet-status
 
 jobs:
   QuickChat-backend:

--- a/src/socket/socket.test.ts
+++ b/src/socket/socket.test.ts
@@ -62,8 +62,8 @@ describe("Test for socket", () => {
       publicKey: "",
       privateKey: "",
       socketId: null,
-      isLogin:true,
-      deviceId:""
+      isLogin: true,
+      deviceId: "",
     };
 
     const user1 = await User.create(sender);
@@ -78,8 +78,8 @@ describe("Test for socket", () => {
       publicKey: "",
       privateKey: "",
       socketId: null,
-      isLogin:true,
-      deviceId:""
+      isLogin: true,
+      deviceId: "",
     };
 
     const user2 = await User.create(receiver);
@@ -90,74 +90,73 @@ describe("Test for socket", () => {
     expect(chat).toBeDefined();
   });
 
- test("should verify device for check_user_device event", (done) => {
-  const phoneNumber = "+919440058888";
-  const correctDeviceId = "device123";
-  const incorrectDeviceId = "wrongDevice";
+  test("should verify device for check_user_device event", (done) => {
+    const phoneNumber = "+919440058888";
+    const correctDeviceId = "device123";
+    const incorrectDeviceId = "wrongDevice";
 
-  User.create({
-    phoneNumber,
-    firstName: "Device",
-    lastName: "Checker",
-    email: "devicechecker@gmail.com",
-    password: "Test@123",
-    isDeleted: false,
-    publicKey: "",
-    privateKey: "",
-    socketId: null,
-    isLogin: false,
-    deviceId: correctDeviceId,
-  }).then(() => {
-    clientA = Client(SERVER_URL);
+    User.create({
+      phoneNumber,
+      firstName: "Device",
+      lastName: "Checker",
+      email: "devicechecker@gmail.com",
+      password: "Test@123",
+      isDeleted: false,
+      publicKey: "",
+      privateKey: "",
+      socketId: null,
+      isLogin: false,
+      deviceId: correctDeviceId,
+    }).then(() => {
+      clientA = Client(SERVER_URL);
 
-    clientA.on("connect", () => {
-      clientA.emit("check_user_device", phoneNumber, correctDeviceId);
+      clientA.on("connect", () => {
+        clientA.emit("check_user_device", phoneNumber, correctDeviceId);
 
-      clientA.once("user_device_verified", (response1) => {
-        try {
-          expect(response1).toEqual({
-            success: true,
-            message: "Device verified",
-            action: "continue",
-          });
+        clientA.once("user_device_verified", (response1) => {
+          try {
+            expect(response1).toEqual({
+              success: true,
+              message: "Device verified",
+              action: "continue",
+            });
 
-          clientA.emit("check_user_device", phoneNumber, incorrectDeviceId);
+            clientA.emit("check_user_device", phoneNumber, incorrectDeviceId);
 
-          clientA.once("user_device_verified", (response2) => {
-            try {
-              expect(response2).toEqual({
-                success: false,
-                message: "Device mismatch - logged in from another device",
-                action: "logout",
-                registeredDeviceId: correctDeviceId,
-              });
+            clientA.once("user_device_verified", (response2) => {
+              try {
+                expect(response2).toEqual({
+                  success: false,
+                  message: "Device mismatch - logged in from another device",
+                  action: "logout",
+                  registeredDeviceId: correctDeviceId,
+                });
 
-              clientA.emit("check_user_device", "+0000000000", "anyDevice");
+                clientA.emit("check_user_device", "+0000000000", "anyDevice");
 
-              clientA.once("user_device_verified", (response3) => {
-                try {
-                  expect(response3).toEqual({
-                    success: false,
-                    message: "User not found",
-                    action: "logout",
-                  });
-                  done();
-                } catch (error) {
-                  done(error);
-                }
-              });
-            } catch (error) {
-              done(error);
-            }
-          });
-        } catch (error) {
-          done(error);
-        }
+                clientA.once("user_device_verified", (response3) => {
+                  try {
+                    expect(response3).toEqual({
+                      success: false,
+                      message: "User not found",
+                      action: "logout",
+                    });
+                    done();
+                  } catch (error) {
+                    done(error);
+                  }
+                });
+              } catch (error) {
+                done(error);
+              }
+            });
+          } catch (error) {
+            done(error);
+          }
+        });
       });
     });
-  });
-}, 15000);
-
+  }, 15000);
 
   test("should handle join event, update socket ID and broadcast to other users", (done) => {
     const phoneNumber = "+919440058803";
@@ -433,6 +432,36 @@ describe("Test for socket", () => {
       setTimeout(() => {
         done();
       }, 1000);
+    });
+  }, 10000);
+
+  test("should handle internet_connection event", (done) => {
+    const phoneNumber = "+919440058820";
+
+    User.create({
+      phoneNumber,
+      firstName: "Connection",
+      lastName: "Test",
+      email: "connection@gmail.com",
+      password: "Test@123",
+      isDeleted: false,
+      publicKey: "",
+      privateKey: "",
+      socketId: null,
+      isLogin: false,
+      deviceId: "",
+    }).then(() => {
+      clientA = Client(SERVER_URL);
+
+      clientA.on("connect", () => {
+        clientA.emit("join", phoneNumber);
+        setTimeout(() => {
+          clientA.emit("internet_connection", { response: true });
+          setTimeout(() => {
+            done();
+          }, 1000);
+        }, 500);
+      });
     });
   }, 10000);
 });


### PR DESCRIPTION
This PR implements a new socket event emission to inform network connection status to the frontend.
### Implementation:
- Emits an internet_connection event with a payload { response: true } to notify that the server has internet connectivity.
- This allows frontend to respond dynamically based on backend connectivity.
- This event is only triggered when the backend confirms an active internet connection.

### Testing:
- It is unit tested with Jest.





